### PR TITLE
Add licence declarations with reuse

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 # Top-most EditorConfig file
 root = true
 

--- a/.env
+++ b/.env
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 REACT_APP_API_URL = ""

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 version: 2
 updates:
   - package-ecosystem: npm

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 name: CI/CD Pipeline
 
 # Trigger the workflow on push or pull request

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,23 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: userfeedbackapp
+Source: https://github.com/diggsweden/userfeedbackapp
+
+Files: package*.json public/**/*.json src/assets/mock.json public/manifest.json
+Copyright: Digg - Agency for Digital Government
+License: CC0-1.0
+
+Files: user_feedback_preview.png
+Copyright: Digg - Agency for Digital Government
+License: CC0-1.0
+
+# Third-party files.
+
+Files: src/assets/fonts/Lato-Regular.ttf
+Copyright: tyPoland Lukasz Dziedzic
+License: OFL-1.1
+
+# these were a bit unclear, in the future please correct,
+#/and replace general ones in the future
+Files: public/*.png public/**/*.svg public/favicon.ico
+Copyright: Facebook
+License: CC0-1.0

--- a/.storybook/i18n.js
+++ b/.storybook/i18n.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: CC0-1.0
+
 import { initReactI18next } from 'react-i18next';
 import i18n from 'i18next';
 import Backend from 'i18next-http-backend';

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: CC0-1.0
+
 /** @type { import('@storybook/react-webpack5').StorybookConfig } */
 const config = {
 	stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
 <link rel="stylesheet" href="../src/assets/css/App.css">
 <link rel="stylesheet" href="../src/assets/css/index.css">
 <style>

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: CC0-1.0
+
 import i18n from './i18n';
 import '../src/assets/css/index.css';
 

--- a/LICENSES/OFL-1.1.txt
+++ b/LICENSES/OFL-1.1.txt
@@ -1,0 +1,43 @@
+SIL OPEN FONT LICENSE
+
+Version 1.1 - 26 February 2007
+
+PREAMBLE
+
+The goals of the Open Font License (OFL) are to stimulate worldwide development of collaborative font projects, to support the font creation efforts of academic and linguistic communities, and to provide a free and open framework in which fonts may be shared and improved in partnership with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and redistributed freely as long as they are not sold by themselves. The fonts, including any derivative works, can be bundled, embedded, redistributed and/or sold with any software provided that any reserved names are not used by derivative works. The fonts and derivatives, however, cannot be released under any other type of license. The requirement for fonts to remain under this license does not apply to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+
+"Font Software" refers to the set of files released by the Copyright Holder(s) under this license and clearly marked as such. This may include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting, or substituting — in part or in whole — any of the components of the Original Version, by changing formats or by porting the Font Software to a new environment.
+
+"Author" refers to any designer, engineer, programmer, technical writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of the Font Software, to use, study, copy, merge, embed, modify, redistribute, and sell modified and unmodified copies of the Font Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components, in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled, redistributed and/or sold with any software, provided that each copy contains the above copyright notice and this license. These can be included either as stand-alone text files, human-readable headers or in the appropriate machine-readable metadata fields within text or binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font Name(s) unless explicit written permission is granted by the corresponding Copyright Holder. This restriction only applies to the primary font name as presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font Software shall not be used to promote, endorse or advertise any Modified Version, except to acknowledge the contribution(s) of the Copyright Holder(s) and the Author(s) or with their explicit written permission.
+
+5) The Font Software, modified or unmodified, in part or in whole, must be distributed entirely under this license, and must not be distributed under any other license. The requirement for fonts to remain under this license does not apply to any document created using the Font Software.
+
+TERMINATION
+
+This license becomes null and void if any of the above conditions are not met.
+
+DISCLAIMER
+
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
 # UserFeedbackApp
+
+[![License: MIT](https://img.shields.io/badge/Licence-MIT-yellow)](https://img.shields.io/badge/Licence-MIT-yellow) 
+
+[![REUSE status](https://api.reuse.software/badge/github.com/diggsweden/userfeedbackapp)](https://api.reuse.software/info/github.com/diggsweden/userfeedbackapp)
+
+
 
 ![User Feedback App](./user_feedback_preview.png)
 

--- a/public/index.html
+++ b/public/index.html
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
 <!DOCTYPE html>
 <html lang="en">
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow:

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import FeedbackContainer from './components/feedbackContainer/feedbackContainer.jsx';

--- a/src/assets/css/App.css
+++ b/src/assets/css/App.css
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
 .user-feedback-app {
 	margin: 0;
 	padding-bottom: 1px;

--- a/src/assets/css/index.css
+++ b/src/assets/css/index.css
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
 @font-face {
 	font-family: 'Lato';
 	src: local('Lato'), url(../fonts/Lato-Regular.ttf) format('truetype');

--- a/src/assets/css/theme/auto.css
+++ b/src/assets/css/theme/auto.css
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
 /**
  * Automatic theme
  */

--- a/src/assets/css/theme/dark.css
+++ b/src/assets/css/theme/dark.css
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
 /**
  * Dark mode colors
  */

--- a/src/assets/css/theme/light.css
+++ b/src/assets/css/theme/light.css
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/*
  * Light mode
  */
 

--- a/src/components/feedbackContainer/feedbackContainer.css
+++ b/src/components/feedbackContainer/feedbackContainer.css
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
 /**
 * Mobile
 */

--- a/src/components/feedbackContainer/feedbackContainer.jsx
+++ b/src/components/feedbackContainer/feedbackContainer.jsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';

--- a/src/components/feedbackContainer/feedbackContainer.stories.js
+++ b/src/components/feedbackContainer/feedbackContainer.stories.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import FeedbackContainer from './feedbackContainer';
 import mock from '../../assets/mock.json';
 

--- a/src/components/feedbackContainer/feedbackContainer.test.js
+++ b/src/components/feedbackContainer/feedbackContainer.test.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import React from 'react';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import FeedbackContainer from './feedbackContainer';

--- a/src/components/feedbackHeader/feedbackHeader.css
+++ b/src/components/feedbackHeader/feedbackHeader.css
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
 .user-feedback-header {
 	display: grid;
 	grid-template-columns: 1fr 24px;

--- a/src/components/feedbackHeader/feedbackHeader.jsx
+++ b/src/components/feedbackHeader/feedbackHeader.jsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import './feedbackHeader.css';

--- a/src/components/feedbackHeader/feedbackHeader.test.js
+++ b/src/components/feedbackHeader/feedbackHeader.test.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
 
 import { render, fireEvent, screen } from '@testing-library/react';
 import { FeedbackHeader } from './feedbackHeader';

--- a/src/components/feedbackReceipt/feedbackReceipt.css
+++ b/src/components/feedbackReceipt/feedbackReceipt.css
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
 .user-feedback-receipt {
 	margin: 0;
 	padding: 9px 16px 27px 16px;

--- a/src/components/feedbackReceipt/feedbackReceipt.jsx
+++ b/src/components/feedbackReceipt/feedbackReceipt.jsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';

--- a/src/components/ratingOption/ratingOption.css
+++ b/src/components/ratingOption/ratingOption.css
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
 /**
 * Reset Button
 */

--- a/src/components/ratingOption/ratingOption.jsx
+++ b/src/components/ratingOption/ratingOption.jsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';

--- a/src/components/ratingOption/ratingOption.stories.js
+++ b/src/components/ratingOption/ratingOption.stories.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import { RatingOption } from './RatingOption';
 
 export default {

--- a/src/components/ratingOption/ratingOption.test.js
+++ b/src/components/ratingOption/ratingOption.test.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
 import RatingOption from './ratingOption';

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import i18n from 'i18next';
 import Backend from 'i18next-http-backend';
 import LanguageDetector from 'i18next-browser-languagedetector';

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import reportWebVitals from './reportWebVitals';

--- a/src/reportWebVitals.js
+++ b/src/reportWebVitals.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 const reportWebVitals = (onPerfEntry) => {
 	if (onPerfEntry && onPerfEntry instanceof Function) {
 		import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {

--- a/src/services/api-service.js
+++ b/src/services/api-service.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import caller from './http-service';
 
 class ApiService {

--- a/src/services/api-service.test.js
+++ b/src/services/api-service.test.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import ApiService from './api-service';
 import caller from './http-service';
 jest.mock('./http-service');

--- a/src/services/http-service.js
+++ b/src/services/http-service.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 /**
  * HTTP fetch based caller
  *

--- a/src/services/http-service.test.js
+++ b/src/services/http-service.test.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import caller from './http-service';
 
 global.fetch = jest.fn();

--- a/src/services/postmessage-service.js
+++ b/src/services/postmessage-service.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 class PostMessageService {
 	constructor() {
 		this.eventHandlers = {};

--- a/src/services/postmessage-service.test.js
+++ b/src/services/postmessage-service.test.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import postMessageService from './postmessage-service'; // Adjust the import path as needed
 
 describe('PostMessageService', () => {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 // jest-dom adds custom jest matchers for asserting on DOM nodes.
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)

--- a/src/utils/debounce-util.js
+++ b/src/utils/debounce-util.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 /**
  * Debounce function
  * @param {Function} func - Function to be executed

--- a/src/utils/event-util.js
+++ b/src/utils/event-util.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 /**
  * Event listeners for the parent iframe.
  *

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 locals {
   s3_origin_id = "S3-origin-${var.bucket_name}"
 

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 # Retrieve github-user as a resource
 data "aws_iam_user" "user" {
   user_name = "github_user"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 terraform {
   required_providers {
     aws = {

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 locals {
 	subdomain = "user-feedback-app"
 }

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 resource "aws_s3_bucket" "user_feedback_app" {
   bucket = var.bucket_name
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 variable "bucket_name" {
   type        = string
   default     = "user-feedback-app-bucket"


### PR DESCRIPTION
This PR makes the project license declare licenses according to https://reuse.software/ so that it passes the reuse lint.

Even though it is many affected files, the pr is scroll friendly and contains no logic. It should be a quick general overview before merging it.

Basically, add adds license headers in spdx-format, as per the resuse-specification. It also adds a missing reuse LICENSES file, ofl 1.1, and the .reuse/dep5 which takes care of the licening for binary files etc.

Note: the reuse badge in the README will be green when the project is public

Note: some files created with the react-app was a bit unsure, see the comment in dep5, and it will be ok for now.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
